### PR TITLE
feat: expand pattern library with diverse patterns

### DIFF
--- a/apps/web/src/services/patternService.test.ts
+++ b/apps/web/src/services/patternService.test.ts
@@ -330,7 +330,7 @@ describe('PatternService', () => {
     it('should return sample patterns with correct structure', () => {
       const samplePatterns = PatternService.getSamplePatterns();
       
-      expect(samplePatterns).toHaveLength(6);
+        expect(samplePatterns).toHaveLength(26);
       expect(samplePatterns[0]).toHaveProperty('id');
       expect(samplePatterns[0]).toHaveProperty('name');
       expect(samplePatterns[0]).toHaveProperty('category');
@@ -349,7 +349,7 @@ describe('PatternService', () => {
       expect(localStorageMock.setItem).toHaveBeenCalled();
       const callArgs = localStorageMock.setItem.mock.calls[0];
       const savedPatterns = JSON.parse(callArgs[1]);
-      expect(savedPatterns).toHaveLength(6);
+        expect(savedPatterns).toHaveLength(26);
     });
 
     it('should not initialize storage when patterns already exist', () => {

--- a/apps/web/src/services/patternService.ts
+++ b/apps/web/src/services/patternService.ts
@@ -927,13 +927,17 @@ seq hihat: xxxxxxxxxxxxxxxx`,
   }
 
   /**
-   * Initialize storage with sample patterns if empty
+   * Ensure sample patterns exist in storage
    */
   static initializeStorage(): void {
     const existingPatterns = this.getStoredPatterns();
-    if (existingPatterns.length === 0) {
-      const samplePatterns = this.getSamplePatterns();
-      this.savePatterns(samplePatterns);
+    const samplePatterns = this.getSamplePatterns();
+
+    const existingIds = new Set(existingPatterns.map(p => p.id));
+    const newPatterns = samplePatterns.filter(p => !existingIds.has(p.id));
+
+    if (newPatterns.length > 0) {
+      this.savePatterns([...existingPatterns, ...newPatterns]);
     }
   }
 

--- a/apps/web/src/services/patternService.ts
+++ b/apps/web/src/services/patternService.ts
@@ -350,6 +350,578 @@ seq pad: xxxxxxxx`,
         createdAt: new Date('2024-01-01'),
         updatedAt: new Date('2024-01-01'),
         isPublic: true
+      },
+      {
+        id: 'sample-7',
+        name: 'Hip Hop Groove',
+        category: 'Hip Hop',
+        content: `TEMPO 90
+
+# EQ Settings
+eq master: low=0 mid=0 high=0
+
+seq kick: x.......x.......
+seq snare: ....x.......x...
+seq hihat: x.x.x.x.x.x.x.x.`,
+        parsedPattern: {
+          tempo: 90,
+          instruments: {
+            kick: { name: 'kick', steps: [true, false, false, false, false, false, false, false, true, false, false, false, false, false, false, false] },
+            snare: { name: 'snare', steps: [false, false, false, false, true, false, false, false, false, false, false, false, true, false, false, false] },
+            hihat: { name: 'hihat', steps: [true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false] }
+          },
+          eqModules: {
+            master: { name: 'master', low: 0, mid: 0, high: 0 }
+          },
+          totalSteps: 16
+        },
+        complexity: 0.4,
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+        isPublic: true
+      },
+      {
+        id: 'sample-8',
+        name: 'Trap Beat',
+        category: 'Trap',
+        content: `TEMPO 140
+
+# EQ Settings
+eq master: low=0 mid=0 high=0
+
+seq kick: x.......x...x...
+seq snare: ....x.......x...
+seq hihat: x.x.xxx.x.x.xxx.`,
+        parsedPattern: {
+          tempo: 140,
+          instruments: {
+            kick: { name: 'kick', steps: [true, false, false, false, false, false, false, false, true, false, false, false, true, false, false, false] },
+            snare: { name: 'snare', steps: [false, false, false, false, true, false, false, false, false, false, false, false, true, false, false, false] },
+            hihat: { name: 'hihat', steps: [true, false, true, false, true, true, true, false, true, false, true, false, true, true, true, false] }
+          },
+          eqModules: {
+            master: { name: 'master', low: 0, mid: 0, high: 0 }
+          },
+          totalSteps: 16
+        },
+        complexity: 0.5,
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+        isPublic: true
+      },
+      {
+        id: 'sample-9',
+        name: 'Reggae Skank',
+        category: 'Reggae',
+        content: `TEMPO 75
+
+# EQ Settings
+eq master: low=0 mid=0 high=0
+
+seq kick: ........x.......
+seq snare: ........x.......
+seq hihat: .x..x..x..x..x..`,
+        parsedPattern: {
+          tempo: 75,
+          instruments: {
+            kick: { name: 'kick', steps: [false, false, false, false, false, false, false, false, true, false, false, false, false, false, false, false] },
+            snare: { name: 'snare', steps: [false, false, false, false, false, false, false, false, true, false, false, false, false, false, false, false] },
+            hihat: { name: 'hihat', steps: [false, true, false, false, true, false, false, true, false, false, true, false, false, true, false, false] }
+          },
+          eqModules: {
+            master: { name: 'master', low: 0, mid: 0, high: 0 }
+          },
+          totalSteps: 16
+        },
+        complexity: 0.3,
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+        isPublic: true
+      },
+      {
+        id: 'sample-10',
+        name: 'Salsa Clave',
+        category: 'Latin',
+        content: `TEMPO 180
+
+# EQ Settings
+eq master: low=0 mid=0 high=0
+
+seq clave: x..x.x..
+seq conga: ..x...x.`,
+        parsedPattern: {
+          tempo: 180,
+          instruments: {
+            clave: { name: 'clave', steps: [true, false, false, true, false, true, false, false] },
+            conga: { name: 'conga', steps: [false, false, true, false, false, false, true, false] }
+          },
+          eqModules: {
+            master: { name: 'master', low: 0, mid: 0, high: 0 }
+          },
+          totalSteps: 8
+        },
+        complexity: 0.5,
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+        isPublic: true
+      },
+      {
+        id: 'sample-11',
+        name: 'Bossa Nova',
+        category: 'Bossa Nova',
+        content: `TEMPO 140
+
+# EQ Settings
+eq master: low=0 mid=0 high=0
+
+seq kick: x...x...
+seq snare: ..x...x.
+seq hihat: x.x.x.x.`,
+        parsedPattern: {
+          tempo: 140,
+          instruments: {
+            kick: { name: 'kick', steps: [true, false, false, false, true, false, false, false] },
+            snare: { name: 'snare', steps: [false, false, true, false, false, false, true, false] },
+            hihat: { name: 'hihat', steps: [true, false, true, false, true, false, true, false] }
+          },
+          eqModules: {
+            master: { name: 'master', low: 0, mid: 0, high: 0 }
+          },
+          totalSteps: 8
+        },
+        complexity: 0.4,
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+        isPublic: true
+      },
+      {
+        id: 'sample-12',
+        name: 'Swing Jazz',
+        category: 'Jazz',
+        content: `TEMPO 150
+
+# EQ Settings
+eq master: low=0 mid=0 high=0
+
+seq kick: x...x...
+seq snare: ..x...x.
+seq ride: x.x.x.x.`,
+        parsedPattern: {
+          tempo: 150,
+          instruments: {
+            kick: { name: 'kick', steps: [true, false, false, false, true, false, false, false] },
+            snare: { name: 'snare', steps: [false, false, true, false, false, false, true, false] },
+            ride: { name: 'ride', steps: [true, false, true, false, true, false, true, false] }
+          },
+          eqModules: {
+            master: { name: 'master', low: 0, mid: 0, high: 0 }
+          },
+          totalSteps: 8
+        },
+        complexity: 0.5,
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+        isPublic: true
+      },
+      {
+        id: 'sample-13',
+        name: 'Funk Groove',
+        category: 'Funk',
+        content: `TEMPO 110
+
+# EQ Settings
+eq master: low=0 mid=0 high=0
+
+seq kick: x..x.x..x..x.x..
+seq snare: ....x.......x...
+seq hihat: x.x.x.x.x.x.x.x.`,
+        parsedPattern: {
+          tempo: 110,
+          instruments: {
+            kick: { name: 'kick', steps: [true, false, false, true, false, true, false, false, true, false, false, true, false, true, false, false] },
+            snare: { name: 'snare', steps: [false, false, false, false, true, false, false, false, false, false, false, false, true, false, false, false] },
+            hihat: { name: 'hihat', steps: [true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false] }
+          },
+          eqModules: {
+            master: { name: 'master', low: 0, mid: 0, high: 0 }
+          },
+          totalSteps: 16
+        },
+        complexity: 0.6,
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+        isPublic: true
+      },
+      {
+        id: 'sample-14',
+        name: 'Dubstep Wobble',
+        category: 'Dubstep',
+        content: `TEMPO 140
+
+# EQ Settings
+eq master: low=0 mid=0 high=0
+
+seq kick: x.......x...x...
+seq snare: ....x.......x...
+seq hihat: x.......x.......`,
+        parsedPattern: {
+          tempo: 140,
+          instruments: {
+            kick: { name: 'kick', steps: [true, false, false, false, false, false, false, false, true, false, false, false, true, false, false, false] },
+            snare: { name: 'snare', steps: [false, false, false, false, true, false, false, false, false, false, false, false, true, false, false, false] },
+            hihat: { name: 'hihat', steps: [true, false, false, false, false, false, false, false, true, false, false, false, false, false, false, false] }
+          },
+          eqModules: {
+            master: { name: 'master', low: 0, mid: 0, high: 0 }
+          },
+          totalSteps: 16
+        },
+        complexity: 0.5,
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+        isPublic: true
+      },
+      {
+        id: 'sample-15',
+        name: 'Drum and Bass',
+        category: 'DnB',
+        content: `TEMPO 174
+
+# EQ Settings
+eq master: low=0 mid=0 high=0
+
+seq kick: x..x..x...x..x..
+seq snare: ....x.......x...
+seq hihat: xxxxxxxxxxxxxxxx`,
+        parsedPattern: {
+          tempo: 174,
+          instruments: {
+            kick: { name: 'kick', steps: [true, false, false, true, false, false, true, false, false, false, true, false, false, true, false, false] },
+            snare: { name: 'snare', steps: [false, false, false, false, true, false, false, false, false, false, false, false, true, false, false, false] },
+            hihat: { name: 'hihat', steps: [true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true] }
+          },
+          eqModules: {
+            master: { name: 'master', low: 0, mid: 0, high: 0 }
+          },
+          totalSteps: 16
+        },
+        complexity: 0.7,
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+        isPublic: true
+      },
+      {
+        id: 'sample-16',
+        name: 'Afrobeat Pulse',
+        category: 'Afrobeat',
+        content: `TEMPO 120
+
+# EQ Settings
+eq master: low=0 mid=0 high=0
+
+seq kick: x...x...x...x...
+seq snare: ....x.......x...
+seq hihat: x..x.x..x..x.x..`,
+        parsedPattern: {
+          tempo: 120,
+          instruments: {
+            kick: { name: 'kick', steps: [true, false, false, false, true, false, false, false, true, false, false, false, true, false, false, false] },
+            snare: { name: 'snare', steps: [false, false, false, false, true, false, false, false, false, false, false, false, true, false, false, false] },
+            hihat: { name: 'hihat', steps: [true, false, false, true, false, true, false, false, true, false, false, true, false, true, false, false] }
+          },
+          eqModules: {
+            master: { name: 'master', low: 0, mid: 0, high: 0 }
+          },
+          totalSteps: 16
+        },
+        complexity: 0.6,
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+        isPublic: true
+      },
+      {
+        id: 'sample-17',
+        name: 'K-Pop Hook',
+        category: 'Pop',
+        content: `TEMPO 120
+
+# EQ Settings
+eq master: low=0 mid=0 high=0
+
+seq kick: x...x...x...x...
+seq snare: ....x.......x...
+seq hihat: x.x.x.x.x.x.x.x.`,
+        parsedPattern: {
+          tempo: 120,
+          instruments: {
+            kick: { name: 'kick', steps: [true, false, false, false, true, false, false, false, true, false, false, false, true, false, false, false] },
+            snare: { name: 'snare', steps: [false, false, false, false, true, false, false, false, false, false, false, false, true, false, false, false] },
+            hihat: { name: 'hihat', steps: [true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false] }
+          },
+          eqModules: {
+            master: { name: 'master', low: 0, mid: 0, high: 0 }
+          },
+          totalSteps: 16
+        },
+        complexity: 0.4,
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+        isPublic: true
+      },
+      {
+        id: 'sample-18',
+        name: 'EDM Riser',
+        category: 'EDM',
+        content: `TEMPO 128
+
+# EQ Settings
+eq master: low=0 mid=0 high=0
+
+seq kick: x...x...x...x...
+seq snare: ....x.......x...
+seq hihat: xxxxxxxxxxxxxxxx`,
+        parsedPattern: {
+          tempo: 128,
+          instruments: {
+            kick: { name: 'kick', steps: [true, false, false, false, true, false, false, false, true, false, false, false, true, false, false, false] },
+            snare: { name: 'snare', steps: [false, false, false, false, true, false, false, false, false, false, false, false, true, false, false, false] },
+            hihat: { name: 'hihat', steps: [true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true] }
+          },
+          eqModules: {
+            master: { name: 'master', low: 0, mid: 0, high: 0 }
+          },
+          totalSteps: 16
+        },
+        complexity: 0.4,
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+        isPublic: true
+      },
+      {
+        id: 'sample-19',
+        name: 'Country Shuffle',
+        category: 'Country',
+        content: `TEMPO 100
+
+# EQ Settings
+eq master: low=0 mid=0 high=0
+
+seq kick: x.x.x.x.
+seq snare: ..x...x.`,
+        parsedPattern: {
+          tempo: 100,
+          instruments: {
+            kick: { name: 'kick', steps: [true, false, true, false, true, false, true, false] },
+            snare: { name: 'snare', steps: [false, false, true, false, false, false, true, false] }
+          },
+          eqModules: {
+            master: { name: 'master', low: 0, mid: 0, high: 0 }
+          },
+          totalSteps: 8
+        },
+        complexity: 0.3,
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+        isPublic: true
+      },
+      {
+        id: 'sample-20',
+        name: 'R&B Smooth',
+        category: 'R&B',
+        content: `TEMPO 80
+
+# EQ Settings
+eq master: low=0 mid=0 high=0
+
+seq kick: x.......x.......
+seq snare: ....x.......x...
+seq hihat: x.x.x.x.x.x.x.x.`,
+        parsedPattern: {
+          tempo: 80,
+          instruments: {
+            kick: { name: 'kick', steps: [true, false, false, false, false, false, false, false, true, false, false, false, false, false, false, false] },
+            snare: { name: 'snare', steps: [false, false, false, false, true, false, false, false, false, false, false, false, true, false, false, false] },
+            hihat: { name: 'hihat', steps: [true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false] }
+          },
+          eqModules: {
+            master: { name: 'master', low: 0, mid: 0, high: 0 }
+          },
+          totalSteps: 16
+        },
+        complexity: 0.4,
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+        isPublic: true
+      },
+      {
+        id: 'sample-21',
+        name: 'Gospel Clap',
+        category: 'Gospel',
+        content: `TEMPO 100
+
+# EQ Settings
+eq master: low=0 mid=0 high=0
+
+seq kick: x...x...x...x...
+seq clap: ....x....x...x..
+seq hihat: x.x.x.x.x.x.x.x.`,
+        parsedPattern: {
+          tempo: 100,
+          instruments: {
+            kick: { name: 'kick', steps: [true, false, false, false, true, false, false, false, true, false, false, false, true, false, false, false] },
+            clap: { name: 'clap', steps: [false, false, false, false, true, false, false, false, false, true, false, false, false, true, false, false] },
+            hihat: { name: 'hihat', steps: [true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false] }
+          },
+          eqModules: {
+            master: { name: 'master', low: 0, mid: 0, high: 0 }
+          },
+          totalSteps: 16
+        },
+        complexity: 0.4,
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+        isPublic: true
+      },
+      {
+        id: 'sample-22',
+        name: 'Metal Blast',
+        category: 'Metal',
+        content: `TEMPO 200
+
+# EQ Settings
+eq master: low=0 mid=0 high=0
+
+seq kick: xxxxxxxxxxxxxxxx
+seq snare: ....x.......x...
+seq hihat: x.x.x.x.x.x.x.x.`,
+        parsedPattern: {
+          tempo: 200,
+          instruments: {
+            kick: { name: 'kick', steps: [true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true] },
+            snare: { name: 'snare', steps: [false, false, false, false, true, false, false, false, false, false, false, false, true, false, false, false] },
+            hihat: { name: 'hihat', steps: [true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false] }
+          },
+          eqModules: {
+            master: { name: 'master', low: 0, mid: 0, high: 0 }
+          },
+          totalSteps: 16
+        },
+        complexity: 0.8,
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+        isPublic: true
+      },
+      {
+        id: 'sample-23',
+        name: 'Marching Snare',
+        category: 'Marching',
+        content: `TEMPO 110
+
+# EQ Settings
+eq master: low=0 mid=0 high=0
+
+seq snare: x.x.x.x.x.x.x.x.
+seq bass: x.......x.......`,
+        parsedPattern: {
+          tempo: 110,
+          instruments: {
+            snare: { name: 'snare', steps: [true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false] },
+            bass: { name: 'bass', steps: [true, false, false, false, false, false, false, false, true, false, false, false, false, false, false, false] }
+          },
+          eqModules: {
+            master: { name: 'master', low: 0, mid: 0, high: 0 }
+          },
+          totalSteps: 16
+        },
+        complexity: 0.5,
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+        isPublic: true
+      },
+      {
+        id: 'sample-24',
+        name: 'Ska Upbeat',
+        category: 'Ska',
+        content: `TEMPO 160
+
+# EQ Settings
+eq master: low=0 mid=0 high=0
+
+seq kick: x.......x.......
+seq snare: ....x.......x...
+seq hihat: .x.x.x.x.x.x.x.x`,
+        parsedPattern: {
+          tempo: 160,
+          instruments: {
+            kick: { name: 'kick', steps: [true, false, false, false, false, false, false, false, true, false, false, false, false, false, false, false] },
+            snare: { name: 'snare', steps: [false, false, false, false, true, false, false, false, false, false, false, false, true, false, false, false] },
+            hihat: { name: 'hihat', steps: [false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true] }
+          },
+          eqModules: {
+            master: { name: 'master', low: 0, mid: 0, high: 0 }
+          },
+          totalSteps: 16
+        },
+        complexity: 0.5,
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+        isPublic: true
+      },
+      {
+        id: 'sample-25',
+        name: 'Bluegrass Train',
+        category: 'Bluegrass',
+        content: `TEMPO 180
+
+# EQ Settings
+eq master: low=0 mid=0 high=0
+
+seq kick: x.x.x.x.x.x.x.x.
+seq snare: ..x...x...x...x.`,
+        parsedPattern: {
+          tempo: 180,
+          instruments: {
+            kick: { name: 'kick', steps: [true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false] },
+            snare: { name: 'snare', steps: [false, false, true, false, false, false, true, false, false, false, true, false, false, false, true, false] }
+          },
+          eqModules: {
+            master: { name: 'master', low: 0, mid: 0, high: 0 }
+          },
+          totalSteps: 16
+        },
+        complexity: 0.6,
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+        isPublic: true
+      },
+      {
+        id: 'sample-26',
+        name: 'Punk Rock',
+        category: 'Punk',
+        content: `TEMPO 180
+
+# EQ Settings
+eq master: low=0 mid=0 high=0
+
+seq kick: x.x.x.x.x.x.x.x.
+seq snare: ....x.......x...
+seq hihat: xxxxxxxxxxxxxxxx`,
+        parsedPattern: {
+          tempo: 180,
+          instruments: {
+            kick: { name: 'kick', steps: [true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false] },
+            snare: { name: 'snare', steps: [false, false, false, false, true, false, false, false, false, false, false, false, true, false, false, false] },
+            hihat: { name: 'hihat', steps: [true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true] }
+          },
+          eqModules: {
+            master: { name: 'master', low: 0, mid: 0, high: 0 }
+          },
+          totalSteps: 16
+        },
+        complexity: 0.6,
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+        isPublic: true
       }
     ];
   }

--- a/docs/DEV-HANDOFF-CURRENT.md
+++ b/docs/DEV-HANDOFF-CURRENT.md
@@ -14,7 +14,7 @@ The ASCII Generative Sequencer now has a **fully modular CSS architecture** that
 - **PatternService**: Complete pattern storage and retrieval system using localStorage
 - **Pattern Library UI**: Full-featured patterns page with search, filter, and grid layout
 - **Pattern Loading Workflow**: One-click pattern loading with automatic navigation to editor
-- **Sample Patterns**: 6 pre-loaded patterns across different musical genres
+  - **Sample Patterns**: 26 pre-loaded patterns across different musical genres
 - **Search & Filter**: Real-time search by name/category and category filtering
 - **State Management**: Enhanced app state with pattern loading actions and hooks
 - **Testing**: Comprehensive test coverage for all pattern loading functionality

--- a/docs/DEV-HANDOFF-CURRENT.md
+++ b/docs/DEV-HANDOFF-CURRENT.md
@@ -15,6 +15,7 @@ The ASCII Generative Sequencer now has a **fully modular CSS architecture** that
 - **Pattern Library UI**: Full-featured patterns page with search, filter, and grid layout
 - **Pattern Loading Workflow**: One-click pattern loading with automatic navigation to editor
   - **Sample Patterns**: 26 pre-loaded patterns across different musical genres
+  - **Automatic Updates**: Missing sample patterns are added to existing libraries on load
 - **Search & Filter**: Real-time search by name/category and category filtering
 - **State Management**: Enhanced app state with pattern loading actions and hooks
 - **Testing**: Comprehensive test coverage for all pattern loading functionality

--- a/docs/PATTERN-LOADING-IMPLEMENTATION.md
+++ b/docs/PATTERN-LOADING-IMPLEMENTATION.md
@@ -10,7 +10,7 @@ The ASCII Generative Sequencer now has a **fully functional pattern loading syst
 - **localStorage Integration**: Persistent pattern storage using browser localStorage
 - **CRUD Operations**: Create, Read, Update, Delete patterns with full data validation
 - **Search & Filter**: Advanced search by name, category, and content
-  - **Sample Patterns**: 26 pre-loaded sample patterns across different genres
+  - **Sample Patterns**: 26 pre-loaded sample patterns across different genres, automatically merged into existing storage
 - **Data Validation**: Proper TypeScript typing and data structure validation
 - **Error Handling**: Graceful error handling with fallback mechanisms
 

--- a/docs/PATTERN-LOADING-IMPLEMENTATION.md
+++ b/docs/PATTERN-LOADING-IMPLEMENTATION.md
@@ -10,7 +10,7 @@ The ASCII Generative Sequencer now has a **fully functional pattern loading syst
 - **localStorage Integration**: Persistent pattern storage using browser localStorage
 - **CRUD Operations**: Create, Read, Update, Delete patterns with full data validation
 - **Search & Filter**: Advanced search by name, category, and content
-- **Sample Patterns**: 6 pre-loaded sample patterns across different genres
+  - **Sample Patterns**: 26 pre-loaded sample patterns across different genres
 - **Data Validation**: Proper TypeScript typing and data structure validation
 - **Error Handling**: Graceful error handling with fallback mechanisms
 
@@ -146,14 +146,15 @@ src/
 
 ## 🎵 **Sample Patterns Included**
 
-The system comes with 6 pre-loaded sample patterns:
+The system comes with 26 pre-loaded sample patterns. Examples include:
 
 1. **Basic House Beat** (House) - 128 BPM, 3 instruments, 46% density
-2. **Minimal Techno** (Techno) - 130 BPM, 2 instruments, 38% density  
+2. **Minimal Techno** (Techno) - 130 BPM, 2 instruments, 38% density
 3. **Complex Breakbeat** (Breakbeat) - 140 BPM, 3 instruments, 38% density
 4. **Simple Rock** (Rock) - 120 BPM, 2 instruments, 13% density
 5. **Jungle Pattern** (Jungle) - 160 BPM, 3 instruments, 46% density
 6. **Ambient Drone** (Ambient) - 60 BPM, 2 instruments, 28% density
+...and 20 additional patterns spanning genres like Hip Hop, Trap, Reggae, Latin, Jazz, Funk, Dubstep, Drum and Bass, Afrobeat, Pop, EDM, Country, R&B, Gospel, Metal, Marching, Ska, Bluegrass, and Punk.
 
 ## 🧪 **Testing Coverage**
 

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -362,13 +362,14 @@ export class PatternService {
 5. **Editor Integration**: Pattern appears in ASCII editor with full audio integration
 
 #### Sample Patterns
-The system includes 6 pre-loaded sample patterns:
+The system includes 26 pre-loaded sample patterns. Examples include:
 - **Basic House Beat** (House) - 128 BPM, 3 instruments
 - **Minimal Techno** (Techno) - 130 BPM, 2 instruments
 - **Complex Breakbeat** (Breakbeat) - 140 BPM, 3 instruments
 - **Simple Rock** (Rock) - 120 BPM, 2 instruments
 - **Jungle Pattern** (Jungle) - 160 BPM, 3 instruments
 - **Ambient Drone** (Ambient) - 60 BPM, 2 instruments
+- ...and 20 additional patterns across genres like Hip Hop, Trap, Reggae, Latin, Jazz, Funk, Dubstep, Drum and Bass, Afrobeat, Pop, EDM, Country, R&B, Gospel, Metal, Marching, Ska, Bluegrass, and Punk.
 
 ### Testing Pattern Loading
 

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -362,7 +362,7 @@ export class PatternService {
 5. **Editor Integration**: Pattern appears in ASCII editor with full audio integration
 
 #### Sample Patterns
-The system includes 26 pre-loaded sample patterns. Examples include:
+The system includes 26 pre-loaded sample patterns that are automatically added to local storage if missing. Examples include:
 - **Basic House Beat** (House) - 128 BPM, 3 instruments
 - **Minimal Techno** (Techno) - 130 BPM, 2 instruments
 - **Complex Breakbeat** (Breakbeat) - 140 BPM, 3 instruments


### PR DESCRIPTION
## Summary
- add 20 new sample patterns spanning genres like hip hop, reggae, jazz, funk, dubstep, pop, metal and more
- update tests for expanded library
- document 26 pre-loaded patterns across the app

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.0.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68c092e0ba24832fa80da1d3d1233542