### PR TITLE
feat: add multi-provider LLM API backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,8 +32,10 @@ REACT_APP_LOG_LEVEL=info
 SUPABASE_URL=your_supabase_project_url
 SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key
 
-# OpenAI Configuration (Backend)
+# AI Provider API Keys (Backend — server-side only)
 OPENAI_API_KEY=your_openai_api_key
+ANTHROPIC_API_KEY=your_anthropic_api_key
+GOOGLE_AI_API_KEY=your_google_ai_api_key
 
 # Vercel Configuration
 VERCEL_URL=your_vercel_deployment_url

--- a/api/ai/generate.ts
+++ b/api/ai/generate.ts
@@ -1,0 +1,123 @@
+/**
+ * POST /api/ai/generate
+ *
+ * Main Vercel serverless endpoint for AI pattern generation.
+ * Accepts a chat conversation, provider choice, current pattern context,
+ * and interaction mode. Streams the LLM response back via SSE.
+ */
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { getSystemPrompt } from './system-prompt';
+import { streamOpenAI } from './providers/openai';
+import { streamAnthropic } from './providers/anthropic';
+import { streamGemini } from './providers/gemini';
+
+export interface ChatMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+interface GenerateRequestBody {
+  messages: ChatMessage[];
+  provider: 'openai' | 'anthropic' | 'gemini';
+  currentPattern?: string;
+  mode: 'generate' | 'modify' | 'teach';
+}
+
+const ALLOWED_PROVIDERS = ['openai', 'anthropic', 'gemini'] as const;
+const ALLOWED_MODES = ['generate', 'modify', 'teach'] as const;
+
+export default async function handler(
+  req: VercelRequest,
+  res: VercelResponse,
+): Promise<void> {
+  // Only accept POST
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  // CORS headers
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+
+  if (req.method === 'OPTIONS') {
+    res.status(200).end();
+    return;
+  }
+
+  // Parse and validate request body
+  const body = req.body as GenerateRequestBody | undefined;
+
+  if (!body || !Array.isArray(body.messages) || body.messages.length === 0) {
+    res.status(400).json({ error: 'messages array is required and must not be empty' });
+    return;
+  }
+
+  const provider = body.provider ?? 'openai';
+  if (!ALLOWED_PROVIDERS.includes(provider as any)) {
+    res.status(400).json({ error: `Invalid provider. Must be one of: ${ALLOWED_PROVIDERS.join(', ')}` });
+    return;
+  }
+
+  const mode = body.mode ?? 'generate';
+  if (!ALLOWED_MODES.includes(mode as any)) {
+    res.status(400).json({ error: `Invalid mode. Must be one of: ${ALLOWED_MODES.join(', ')}` });
+    return;
+  }
+
+  // Validate message structure
+  for (const msg of body.messages) {
+    if (!msg.role || !msg.content || typeof msg.content !== 'string') {
+      res.status(400).json({ error: 'Each message must have a role and content string' });
+      return;
+    }
+    if (msg.role !== 'user' && msg.role !== 'assistant') {
+      res.status(400).json({ error: 'Message role must be "user" or "assistant"' });
+      return;
+    }
+  }
+
+  // Build the system prompt, optionally injecting the current pattern
+  let systemPrompt = getSystemPrompt(mode);
+  if (body.currentPattern) {
+    systemPrompt += `\n\n## Current Pattern\nThe user is currently working with this pattern:\n\`\`\`pattern\n${body.currentPattern}\n\`\`\`\n`;
+  }
+
+  // Set SSE headers
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+  res.setHeader('X-Accel-Buffering', 'no');
+
+  try {
+    switch (provider) {
+      case 'openai':
+        await streamOpenAI(body.messages, systemPrompt, res);
+        break;
+      case 'anthropic':
+        await streamAnthropic(body.messages, systemPrompt, res);
+        break;
+      case 'gemini':
+        await streamGemini(body.messages, systemPrompt, res);
+        break;
+    }
+
+    // Signal completion
+    res.write('data: [DONE]\n\n');
+    res.end();
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'Internal server error';
+    console.error(`[ai/generate] ${provider} error:`, err);
+
+    // If headers already sent (streaming started), send error as SSE event
+    if (res.headersSent) {
+      res.write(`data: ${JSON.stringify({ error: message })}\n\n`);
+      res.write('data: [DONE]\n\n');
+      res.end();
+    } else {
+      res.status(500).json({ error: message });
+    }
+  }
+}

--- a/api/ai/providers/anthropic.ts
+++ b/api/ai/providers/anthropic.ts
@@ -1,0 +1,40 @@
+/**
+ * Anthropic provider adapter for the AI generate endpoint.
+ * Wraps the Anthropic SDK to provide streaming chat completions.
+ */
+import Anthropic from '@anthropic-ai/sdk';
+import type { ChatMessage } from '../generate';
+
+const DEFAULT_MODEL = 'claude-sonnet-4-5-20250929';
+
+export async function streamAnthropic(
+  messages: ChatMessage[],
+  systemPrompt: string,
+  res: { write: (chunk: string) => void },
+): Promise<void> {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    throw new Error('ANTHROPIC_API_KEY is not configured');
+  }
+
+  const client = new Anthropic({ apiKey });
+
+  const stream = client.messages.stream({
+    model: DEFAULT_MODEL,
+    max_tokens: 2048,
+    system: systemPrompt,
+    messages: messages.map((m) => ({
+      role: m.role as 'user' | 'assistant',
+      content: m.content,
+    })),
+  });
+
+  for await (const event of stream) {
+    if (
+      event.type === 'content_block_delta' &&
+      event.delta.type === 'text_delta'
+    ) {
+      res.write(`data: ${JSON.stringify({ content: event.delta.text })}\n\n`);
+    }
+  }
+}

--- a/api/ai/providers/gemini.ts
+++ b/api/ai/providers/gemini.ts
@@ -1,0 +1,47 @@
+/**
+ * Google Gemini provider adapter for the AI generate endpoint.
+ * Wraps the Google Generative AI SDK to provide streaming chat completions.
+ */
+import { GoogleGenerativeAI } from '@google/generative-ai';
+import type { ChatMessage } from '../generate';
+
+const DEFAULT_MODEL = 'gemini-2.0-flash';
+
+export async function streamGemini(
+  messages: ChatMessage[],
+  systemPrompt: string,
+  res: { write: (chunk: string) => void },
+): Promise<void> {
+  const apiKey = process.env.GOOGLE_AI_API_KEY;
+  if (!apiKey) {
+    throw new Error('GOOGLE_AI_API_KEY is not configured');
+  }
+
+  const genAI = new GoogleGenerativeAI(apiKey);
+  const model = genAI.getGenerativeModel({
+    model: DEFAULT_MODEL,
+    systemInstruction: systemPrompt,
+  });
+
+  // Convert chat messages to Gemini's history format.
+  // Gemini uses "user" and "model" roles. History must not include the last user message.
+  const history = messages.slice(0, -1).map((m) => ({
+    role: m.role === 'assistant' ? 'model' : 'user',
+    parts: [{ text: m.content }],
+  }));
+
+  const lastMessage = messages[messages.length - 1];
+  if (!lastMessage || lastMessage.role !== 'user') {
+    throw new Error('Last message must be from the user');
+  }
+
+  const chat = model.startChat({ history });
+  const result = await chat.sendMessageStream(lastMessage.content);
+
+  for await (const chunk of result.stream) {
+    const text = chunk.text();
+    if (text) {
+      res.write(`data: ${JSON.stringify({ content: text })}\n\n`);
+    }
+  }
+}

--- a/api/ai/providers/openai.ts
+++ b/api/ai/providers/openai.ts
@@ -1,0 +1,42 @@
+/**
+ * OpenAI provider adapter for the AI generate endpoint.
+ * Wraps the OpenAI SDK to provide streaming chat completions.
+ */
+import OpenAI from 'openai';
+import type { ChatMessage } from '../generate';
+
+const DEFAULT_MODEL = 'gpt-4o-mini';
+
+export async function streamOpenAI(
+  messages: ChatMessage[],
+  systemPrompt: string,
+  res: { write: (chunk: string) => void },
+): Promise<void> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new Error('OPENAI_API_KEY is not configured');
+  }
+
+  const client = new OpenAI({ apiKey });
+
+  const stream = await client.chat.completions.create({
+    model: DEFAULT_MODEL,
+    stream: true,
+    messages: [
+      { role: 'system', content: systemPrompt },
+      ...messages.map((m) => ({
+        role: m.role as 'user' | 'assistant',
+        content: m.content,
+      })),
+    ],
+    temperature: 0.7,
+    max_tokens: 2048,
+  });
+
+  for await (const chunk of stream) {
+    const content = chunk.choices[0]?.delta?.content;
+    if (content) {
+      res.write(`data: ${JSON.stringify({ content })}\n\n`);
+    }
+  }
+}

--- a/api/ai/system-prompt.ts
+++ b/api/ai/system-prompt.ts
@@ -68,9 +68,9 @@ export function getSystemPrompt(mode: 'generate' | 'modify' | 'teach'): string {
   - Example: \`pan hihat: 0.3\`
 
 ### Distortion (New)
-- \`distort <instrument>: amount=<0..100> [mix=<0..1>]\`
-  - Apply distortion/overdrive
-  - Example: \`distort bass: amount=30 mix=0.5\`
+- \`distort <instrument>: amount=<0..1> [mix=<0..1>]\`
+  - Apply distortion/overdrive (amount 0 = clean, 1 = max distortion)
+  - Example: \`distort bass: amount=0.3 mix=0.5\`
 
 ## Pattern Guidelines
 - Always start with \`TEMPO\`

--- a/api/ai/system-prompt.ts
+++ b/api/ai/system-prompt.ts
@@ -1,0 +1,114 @@
+/**
+ * DSL-aware system prompt for the ASCII Generative Sequencer AI assistant.
+ * Contains the full syntax reference so the LLM can produce valid patterns.
+ */
+
+export function getSystemPrompt(mode: 'generate' | 'modify' | 'teach'): string {
+  const base = `You are an AI music assistant for the ASCII Generative Sequencer, a browser-based music tool that uses a text DSL to define drum patterns and synth sequences.
+
+## DSL Syntax Reference
+
+### Global Settings
+- \`TEMPO <60-200>\` — Set beats per minute (default: 120)
+
+### Sequences
+- \`seq <name>: <pattern>\` — Define a step sequence
+  - \`x\` = hit, \`.\` = rest, \`X\` = accent (treated as hit)
+  - Pattern length determines the loop length (max 32 steps)
+  - Common instrument names: kick, snare, hihat, clap, rim, tom, perc, bass, lead, pad, pluck, bell
+  - Example: \`seq kick: x...x...x...x...\`
+
+### Sample Assignment
+- \`sample <instrument>: <sampleName> [gain=<-3..3>]\`
+  - Maps an instrument to a different sample from the library
+  - Optional gain adjustment in integer steps (-3 to +3)
+  - Example: \`sample hihat: openhat gain=-1\`
+
+### EQ (Equalizer)
+- \`eq <instrument>: [low=<-3..3>] [mid=<-3..3>] [high=<-3..3>]\`
+  - Any combination of low/mid/high bands, in any order
+  - Values are integer steps from -3 to +3 (0 = flat)
+  - Example: \`eq kick: low=2 mid=-1 high=0\`
+
+### Amp (Gain)
+- \`amp <instrument>: gain=<-3..3>\`
+  - Adjust overall gain for an instrument
+  - Example: \`amp snare: gain=1\`
+
+### Compressor
+- \`comp <instrument>: [threshold=<-60..0>] [ratio=<1..20>] [attack=<0.001..0.3>] [release=<0.02..1>] [knee=<0..40>]\`
+  - All parameters optional, defaults: threshold=-24, ratio=4, attack=0.01, release=0.25, knee=30
+  - Example: \`comp kick: threshold=-18 ratio=6 attack=0.005\`
+
+### LFO (Low Frequency Oscillator)
+- \`lfo <instrument>.amp: [rate=<0.1..20>Hz] [depth=<0..1>] [wave=<sine|triangle|square|sawtooth>]\`
+  - Modulates the amplitude of an instrument or master
+  - Use \`master.amp\` for global tremolo
+  - Example: \`lfo hihat.amp: rate=4Hz depth=0.3 wave=sine\`
+
+### Filter (New)
+- \`filter <instrument>: type=<lowpass|highpass|bandpass> freq=<20..20000> [q=<0.1..30>]\`
+  - Apply a filter to an instrument's output
+  - Example: \`filter bass: type=lowpass freq=800 q=2\`
+
+### Delay (New)
+- \`delay <instrument>: time=<0.01..2> [feedback=<0..0.95>] [mix=<0..1>]\`
+  - Add echo/delay effect
+  - time in seconds, feedback controls repeats, mix is dry/wet balance
+  - Example: \`delay snare: time=0.375 feedback=0.4 mix=0.3\`
+
+### Reverb (New)
+- \`reverb <instrument>: decay=<0.1..10> [mix=<0..1>] [preDelay=<0..0.1>]\`
+  - Add reverb/space effect
+  - Example: \`reverb clap: decay=2.5 mix=0.4\`
+
+### Pan (New)
+- \`pan <instrument>: <-1..1>\`
+  - Stereo panning: -1 = full left, 0 = center, 1 = full right
+  - Example: \`pan hihat: 0.3\`
+
+### Distortion (New)
+- \`distort <instrument>: amount=<0..100> [mix=<0..1>]\`
+  - Apply distortion/overdrive
+  - Example: \`distort bass: amount=30 mix=0.5\`
+
+## Pattern Guidelines
+- Always start with \`TEMPO\`
+- Define sequences with \`seq\` lines
+- Add effects/processing after sequences
+- Use 16-step patterns for standard 4/4 time (each step = 16th note at 4 steps per beat)
+- Use 8-step patterns for half-time or simpler grooves
+- Keep instrument names consistent between seq, eq, amp, comp, lfo, filter, delay, reverb, pan, distort lines
+- Patterns should be musically coherent — kicks on 1 and 3, snares on 2 and 4 for standard beats
+
+## Output Format
+Always output patterns inside a fenced code block with the \`pattern\` language tag:
+
+\`\`\`pattern
+TEMPO 120
+seq kick:  x...x...x...x...
+seq snare: ....x.......x...
+seq hihat: x.x.x.x.x.x.x.x.
+\`\`\`
+`;
+
+  switch (mode) {
+    case 'generate':
+      return base + `
+## Mode: Generate
+Generate new patterns based on the user's description. Output a complete, playable pattern in a fenced code block. Add a brief one-line description before the code block. Do not over-explain.`;
+
+    case 'modify':
+      return base + `
+## Mode: Modify
+The user has an existing pattern they want to change. Look at the current pattern they provide, apply the requested modifications, and output the full updated pattern in a fenced code block. Briefly explain what you changed.`;
+
+    case 'teach':
+      return base + `
+## Mode: Teach
+The user wants to learn about pattern creation. When you output a pattern, explain each line — what it does, why it sounds good, and how the user could modify it. Be educational but concise.`;
+
+    default:
+      return base;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -26,7 +26,13 @@
     "deploy:prod": "vercel --prod",
     "deploy:quick": "./scripts/deploy.sh --skip-tests"
   },
+  "dependencies": {
+    "@anthropic-ai/sdk": "^0.39.0",
+    "@google/generative-ai": "^0.24.0",
+    "openai": "^4.77.0"
+  },
   "devDependencies": {
+    "@vercel/node": "^5.0.0",
     "@types/node": "^22.10.0",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",

--- a/vercel.json
+++ b/vercel.json
@@ -39,7 +39,16 @@
       ]
     }
   ],
+  "functions": {
+    "api/**/*.ts": {
+      "maxDuration": 30
+    }
+  },
   "rewrites": [
+    {
+      "source": "/api/ai/generate",
+      "destination": "/api/ai/generate"
+    },
     {
       "source": "/(.*)",
       "destination": "/index.html"


### PR DESCRIPTION
## Summary
- Adds Vercel serverless API endpoint (`/api/ai/generate`) with streaming response support
- Implements three LLM provider adapters: OpenAI, Anthropic (Claude), and Google Gemini
- Includes a detailed system prompt that teaches the LLM the ASCII Sequencer DSL for pattern generation

## Test plan
- [ ] Verify `/api/ai/generate` endpoint responds with streaming text
- [ ] Test each provider (OpenAI, Anthropic, Gemini) with valid API keys
- [ ] Confirm system prompt produces valid DSL patterns
- [ ] Verify error handling for missing/invalid API keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)