### PR TITLE
feat: expand LFO routing to modulate all effect parameters

### DIFF
--- a/api/ai/system-prompt.ts
+++ b/api/ai/system-prompt.ts
@@ -80,10 +80,22 @@ Teach about the DSL, pattern concepts, or music theory. Be educational but conci
   - Example: \`comp kick: threshold=-18 ratio=6 attack=0.005\`
 
 ### LFO (Low Frequency Oscillator)
-- \`lfo <instrument>.amp: [rate=<0.1..20>Hz] [depth=<0..1>] [wave=<sine|triangle|square|sawtooth>]\`
-  - Modulates the amplitude of an instrument or master
-  - Use \`master.amp\` for global tremolo
-  - Example: \`lfo hihat.amp: rate=4Hz depth=0.3 wave=sine\`
+- \`lfo <name>.<target>: [rate=<0.1..20>Hz] [depth=<0..1>] [wave=<sine|triangle|square|sawtooth>]\`
+  - Modulates a parameter over time using an oscillator
+  - **Valid targets:**
+    - \`amp\` — amplitude/volume (tremolo). Works on instruments and master.
+    - \`filter.freq\` — filter cutoff frequency (filter sweep). Instrument only.
+    - \`filter.q\` — filter resonance (resonance wobble). Instrument only.
+    - \`pan\` — stereo position (auto-pan). Instrument only.
+    - \`delay.time\` — delay time (chorus/flanger). Master only.
+    - \`delay.feedback\` — delay feedback (echo swell). Master only.
+  - **Scope rules:** \`filter.*\` and \`pan\` are instrument-only. \`delay.*\` is master-only. \`amp\` works on both.
+  - Examples:
+    - \`lfo hihat.amp: rate=4Hz depth=0.3 wave=sine\` — tremolo on hi-hat
+    - \`lfo kick.filter.freq: rate=0.5Hz depth=0.6 wave=triangle\` — filter sweep on kick
+    - \`lfo hihat.pan: rate=3Hz depth=0.8 wave=sine\` — auto-pan on hi-hat
+    - \`lfo master.delay.time: rate=0.3Hz depth=0.2 wave=triangle\` — subtle chorus
+    - \`lfo master.amp: rate=2Hz depth=0.3 wave=sine\` — global tremolo
 
 ### Filter
 - \`filter <instrument>: type=<lowpass|highpass|bandpass> freq=<20..20000> [q=<0.1..30>]\`

--- a/apps/web/src/components/visualizations/audio/AudioEffects.tsx
+++ b/apps/web/src/components/visualizations/audio/AudioEffects.tsx
@@ -21,7 +21,14 @@ export const AudioEffects: React.FC<AudioEffectsProps> = ({
     );
   }
 
-  const hasEQSettings = pattern.eqModules && Object.keys(pattern.eqModules).length > 0;
+  const hasEQ = pattern.eqModules && Object.keys(pattern.eqModules).length > 0;
+  const hasFilters = pattern.filterModules && Object.keys(pattern.filterModules).length > 0;
+  const hasLFOs = pattern.lfoModules && Object.keys(pattern.lfoModules).length > 0;
+  const hasDelay = pattern.delayModules && Object.keys(pattern.delayModules).length > 0;
+  const hasReverb = pattern.reverbModules && Object.keys(pattern.reverbModules).length > 0;
+  const hasPan = pattern.panModules && Object.keys(pattern.panModules).length > 0;
+  const hasDistort = pattern.distortModules && Object.keys(pattern.distortModules).length > 0;
+  const hasAny = hasEQ || hasFilters || hasLFOs || hasDelay || hasReverb || hasPan || hasDistort;
 
   return (
     <BaseVisualization
@@ -31,54 +38,136 @@ export const AudioEffects: React.FC<AudioEffectsProps> = ({
     >
       <div className="space-y-4">
         {/* EQ Settings */}
-        {hasEQSettings && (
+        {hasEQ && (
           <div>
             <h4 className="text-sm font-semibold mb-3 text-foreground">EQ Settings</h4>
             <EQDisplay eqModules={pattern.eqModules} />
           </div>
         )}
 
-        {/* Placeholder for future effects */}
-        {!hasEQSettings && (
+        {/* Filters */}
+        {hasFilters && (
+          <div>
+            <h4 className="text-sm font-semibold mb-2 text-foreground">Filters</h4>
+            <div className="space-y-1">
+              {Object.entries(pattern.filterModules!).map(([name, f]) => (
+                <div key={name} className="flex items-center gap-2 text-xs">
+                  <span className="text-accent font-medium w-16 truncate">{name}</span>
+                  <span className="text-foreground-muted">{f.type}</span>
+                  <span className="text-foreground">{f.freq}Hz</span>
+                  <span className="text-foreground-muted">Q={f.Q}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* LFO Modulation */}
+        {hasLFOs && (
+          <div>
+            <h4 className="text-sm font-semibold mb-2 text-foreground">LFO Modulation</h4>
+            <div className="space-y-1.5">
+              {Object.entries(pattern.lfoModules!).map(([key, lfo]) => (
+                <div key={key} className="flex items-center gap-2 text-xs">
+                  <span className="text-accent font-medium w-24 truncate">{key}</span>
+                  <span className="text-foreground">{lfo.rateHz}Hz</span>
+                  <span className="text-foreground-muted">{lfo.wave}</span>
+                  <div className="flex-1 max-w-20 h-1.5 bg-background-secondary rounded-full overflow-hidden">
+                    <div
+                      className="h-full bg-accent rounded-full"
+                      style={{ width: `${lfo.depth * 100}%` }}
+                    />
+                  </div>
+                  <span className="text-foreground-muted w-8 text-right">{Math.round(lfo.depth * 100)}%</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Delay */}
+        {hasDelay && (
+          <div>
+            <h4 className="text-sm font-semibold mb-2 text-foreground">Delay</h4>
+            <div className="space-y-1">
+              {Object.entries(pattern.delayModules!).map(([name, d]) => (
+                <div key={name} className="flex items-center gap-2 text-xs">
+                  <span className="text-accent font-medium w-16 truncate">{name}</span>
+                  <span className="text-foreground">{d.time}s</span>
+                  <span className="text-foreground-muted">fb={d.feedback}</span>
+                  <span className="text-foreground-muted">mix={d.mix}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Reverb */}
+        {hasReverb && (
+          <div>
+            <h4 className="text-sm font-semibold mb-2 text-foreground">Reverb</h4>
+            <div className="space-y-1">
+              {Object.entries(pattern.reverbModules!).map(([name, r]) => (
+                <div key={name} className="flex items-center gap-2 text-xs">
+                  <span className="text-accent font-medium w-16 truncate">{name}</span>
+                  <span className="text-foreground">decay={r.decay}s</span>
+                  <span className="text-foreground-muted">mix={r.mix}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Pan */}
+        {hasPan && (
+          <div>
+            <h4 className="text-sm font-semibold mb-2 text-foreground">Pan</h4>
+            <div className="space-y-1">
+              {Object.entries(pattern.panModules!).map(([name, p]) => (
+                <div key={name} className="flex items-center gap-2 text-xs">
+                  <span className="text-accent font-medium w-16 truncate">{name}</span>
+                  <span className="text-foreground-muted">L</span>
+                  <div className="flex-1 max-w-20 h-1.5 bg-background-secondary rounded-full relative">
+                    <div
+                      className="absolute top-0 h-full w-1.5 bg-accent rounded-full"
+                      style={{ left: `${((p.value + 1) / 2) * 100}%`, transform: 'translateX(-50%)' }}
+                    />
+                  </div>
+                  <span className="text-foreground-muted">R</span>
+                  <span className="text-foreground w-8 text-right">{p.value.toFixed(1)}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Distortion */}
+        {hasDistort && (
+          <div>
+            <h4 className="text-sm font-semibold mb-2 text-foreground">Distortion</h4>
+            <div className="space-y-1">
+              {Object.entries(pattern.distortModules!).map(([name, d]) => (
+                <div key={name} className="flex items-center gap-2 text-xs">
+                  <span className="text-accent font-medium w-16 truncate">{name}</span>
+                  <span className="text-foreground">amount={d.amount}</span>
+                  <span className="text-foreground-muted">mix={d.mix}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* No effects fallback */}
+        {!hasAny && (
           <div className="text-center py-4">
             <div className="text-foreground-muted text-sm mb-2">
               No audio effects applied
             </div>
             <div className="text-xs text-foreground-muted">
-              Add EQ settings in your ASCII pattern to see them here
+              Add EQ, filter, LFO, delay, reverb, pan, or distort commands to see them here
             </div>
           </div>
         )}
-
-        {/* Future effects sections */}
-        <div className="space-y-3">
-          <div className="bg-background-secondary rounded p-3 border border-dashed border-border">
-            <div className="text-sm font-medium text-foreground-muted mb-1">
-              🎛️ Filters
-            </div>
-            <div className="text-xs text-foreground-muted">
-              Low-pass, high-pass, and band-pass filters
-            </div>
-          </div>
-
-          <div className="bg-background-secondary rounded p-3 border border-dashed border-border">
-            <div className="text-sm font-medium text-foreground-muted mb-1">
-              🎚️ Dynamics
-            </div>
-            <div className="text-xs text-foreground-muted">
-              Compression, limiting, and gating
-            </div>
-          </div>
-
-          <div className="bg-background-secondary rounded p-3 border border-dashed border-border">
-            <div className="text-sm font-medium text-foreground-muted mb-1">
-              🌊 Modulation
-            </div>
-            <div className="text-xs text-foreground-muted">
-              Chorus, flanger, and phaser effects
-            </div>
-          </div>
-        </div>
       </div>
     </BaseVisualization>
   );

--- a/apps/web/src/types/app.ts
+++ b/apps/web/src/types/app.ts
@@ -57,12 +57,13 @@ export interface DistortModule {
 }
 
 export type LFOWave = 'sine' | 'triangle' | 'square' | 'sawtooth';
+export type LFOTarget = 'amp' | 'filter.freq' | 'filter.q' | 'pan' | 'delay.time' | 'delay.feedback';
 
 export interface LFOModule {
-  // key like 'master.amp' or 'kick.amp'
+  // key like 'master.amp' or 'kick.filter.freq'
   key: string;
   scope: 'master' | 'instrument';
-  target: 'amp';
+  target: LFOTarget;
   name: string; // instrument name or 'master'
   rateHz: number; // 0.1..20
   depth: number;  // 0..1


### PR DESCRIPTION
## Summary
- Expands LFO system from amplitude-only to 6 modulation targets: `amp`, `filter.freq`, `filter.q`, `pan`, `delay.time`, `delay.feedback`
- Enforces scope rules in parser: `filter.*`/`pan` instrument-only, `delay.*` master-only, `amp` both
- Adds `resolveLFOTarget()` engine method mapping each target to the correct `AudioParam` with depth scaling

## Changes (7 files)
- **Types**: New `LFOTarget` union type, updated `LFOModule.target`
- **Parser**: `VALID_LFO_TARGETS` constant, rewritten `parseLFOString()` with dotted-path support (2-part and 3-part) and scope validation, updated error messages
- **Audio engine**: `resolveLFOTarget()` method, refactored `updateLFO()` to use it
- **AudioEffects UI**: Replaced placeholders with live displays for filters, LFOs (depth bars), delay, reverb, pan (L/R indicator), distortion
- **Editor highlighting**: Syntax coloring for `lfo` lines and all effect keywords (`filter`, `delay`, `reverb`, `distort`, `comp`, `amp`, `pan`)
- **AI system prompt**: Expanded LFO docs with all 6 targets, scope rules, and examples
- **Tests**: 15 new tests covering all targets, scope enforcement, backward compat, validation errors (287 total, all passing)

## Test plan
- [x] `pnpm test` — 287/287 pass (272 existing + 15 new)
- [ ] Manual: `lfo kick.filter.freq: rate=0.5Hz depth=0.6 wave=triangle` with `filter kick: type=lowpass freq=800` — audible filter sweep
- [ ] Manual: `lfo hihat.pan: rate=3Hz depth=0.8 wave=sine` — hi-hat pans L/R
- [ ] Manual: `lfo master.delay.time: rate=0.3Hz depth=0.2 wave=triangle` — subtle chorus
- [ ] Manual: `lfo kick.amp: rate=2Hz depth=0.3 wave=sine` — existing tremolo still works
- [ ] UI: AudioEffects panel shows active LFOs with params
- [ ] Editor: LFO lines have proper syntax highlighting

🤖 Generated with [Claude Code](https://claude.com/claude-code)