### PR TITLE
feat: groove template system with 13 genre presets

### DIFF
--- a/api/_lib/system-prompt.ts
+++ b/api/_lib/system-prompt.ts
@@ -75,20 +75,29 @@ Generate a complete new pattern from the user's description. Add a brief one-lin
   - Example: \`seq kick: X...x...o...x...\`
 
 ### Groove & Feel
-- \`groove <instrument|master>: type=<swing|humanize|rush|drag> amount=<0..1> [steps=<odd|even|all|indices>] [subdivision=<8n|16n|4n>]\`
+- \`groove <instrument|master>: type=<swing|humanize|rush|drag|template> amount=<0..1> [steps=<odd|even|all|indices>] [subdivision=<8n|16n|4n>] [name=<preset>]\`
   - **swing** — MPC-style swing, delays offbeat notes at the given subdivision level
   - **humanize** — Random micro-timing variation
   - **rush** — Push notes slightly ahead of the beat
   - **drag** — Pull notes slightly behind the beat
+  - **template** — Apply a named groove preset with per-step timing offsets and velocity shaping. Requires \`name=<preset>\`.
   - \`subdivision\` — The rhythmic level at which swing operates (swing only):
     - \`8n\` (default) — Delays offbeat 8th notes. Standard swing feel. **Use this for most patterns.**
     - \`16n\` — Delays offbeat 16th notes. Subtle hi-hat shuffle.
     - \`4n\` — Delays offbeat quarter notes. Half-time, wide swing feel.
   - \`steps\` — Override subdivision with explicit step targeting: \`odd\`, \`even\`, \`all\`, or comma-separated indices (e.g. \`1,3,5\`). When set, overrides \`subdivision\`.
+  - Available template presets:
+    - **Swing**: \`mpc-swing-54\`, \`mpc-swing-58\`, \`mpc-swing-62\`, \`mpc-swing-66\`, \`mpc-swing-71\`
+    - **Latin**: \`bossa-nova\`, \`son-clave-3-2\`, \`rumba-clave-3-2\`
+    - **African**: \`afrobeat-12-8\`
+    - **Reggae**: \`reggae-one-drop\`
+    - **Funk**: \`second-line\`, \`go-go-swing\`, \`dilla-feel\`
   - Example: \`groove master: type=swing amount=0.6\` (8th-note swing by default)
   - Example: \`groove master: type=swing amount=0.6 subdivision=8n\` (same as above, explicit)
   - Example: \`groove hihat: type=swing amount=0.4 subdivision=16n\` (16th-note shuffle on hats)
   - Example: \`groove hihat: type=humanize amount=0.3 steps=all\`
+  - Example: \`groove master: type=template name=bossa-nova amount=0.8\`
+  - Example: \`groove kick: type=template name=mpc-swing-66 amount=0.7\`
 
 ### Synthesis & Sound Design
 - \`sample <instrument>: <sampleName> [gain=<-3..3>]\`
@@ -175,13 +184,41 @@ seq kick:  x...x...x...x...
 seq hihat: .x.x.x.x.x.x.x.x
 \`\`\`
 
+### Bossa Nova (Template Groove)
+\`\`\`pattern
+TEMPO 130
+groove master: type=template name=bossa-nova amount=0.8
+seq kick:  x..x..x...x..x..
+seq rim:   ...x..x....x..x.
+seq hat:   x.x.x.x.x.x.x.x.
+\`\`\`
+
+### Afrobeat 12/8 (Template Groove)
+\`\`\`pattern
+TEMPO 115
+groove master: type=template name=afrobeat-12-8 amount=0.7
+seq kick:  x..x..x..x..x...
+seq snare: ....x.......x...
+seq hat:   x.x.x.x.x.x.x.x.
+seq bell:  x..x..x.x..x..x.
+\`\`\`
+
+### MPC Swing 66% (Template Groove)
+\`\`\`pattern
+TEMPO 94
+groove master: type=template name=mpc-swing-66 amount=1.0
+seq kick:  x...x..x..x.x...
+seq snare: ....x.......x...
+seq hat:   x.x.x.x.x.x.x.x.
+\`\`\`
+
 ## Pattern Guidelines
 - **Always start with \`TEMPO\`**
 - Use 16-step patterns for standard 4/4 time.
 - Keep instrument names consistent and lowercase.
 - **Articulation:** Use effects (ADSR, Filter) to shape sound, NOT different sequence characters.
 - **Pitch:** Use \`note\` command for distinct pitches (e.g. \`note bass: 36\`).
-- **Groove:** Use \`groove\` for swing/feel — never shift notes manually. For swing, use \`subdivision=8n\` (default) for standard swing, \`subdivision=16n\` for hi-hat shuffle, \`subdivision=4n\` for half-time feel.
+- **Groove:** Use \`groove\` for swing/feel — never shift notes manually. For swing, use \`subdivision=8n\` (default) for standard swing, \`subdivision=16n\` for hi-hat shuffle, \`subdivision=4n\` for half-time feel. Use \`type=template\` with \`name=<preset>\` for genre-specific grooves (bossa nova, afrobeat, etc.).
 
 ## Output Format
 Always output patterns inside a fenced code block with the \`pattern\` language tag.

--- a/apps/web/src/services/groovePresets.test.ts
+++ b/apps/web/src/services/groovePresets.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from 'vitest';
+import {
+  GROOVE_PRESETS,
+  getGrooveTemplate,
+  getGrooveTemplateNames,
+  getGrooveTemplatesByCategory,
+  applyGrooveTemplate,
+} from './groovePresets';
+
+describe('Groove Presets', () => {
+  describe('GROOVE_PRESETS library', () => {
+    it('should contain all expected presets', () => {
+      const names = getGrooveTemplateNames();
+      expect(names).toContain('mpc-swing-54');
+      expect(names).toContain('mpc-swing-58');
+      expect(names).toContain('mpc-swing-62');
+      expect(names).toContain('mpc-swing-66');
+      expect(names).toContain('mpc-swing-71');
+      expect(names).toContain('bossa-nova');
+      expect(names).toContain('son-clave-3-2');
+      expect(names).toContain('rumba-clave-3-2');
+      expect(names).toContain('afrobeat-12-8');
+      expect(names).toContain('reggae-one-drop');
+      expect(names).toContain('second-line');
+      expect(names).toContain('go-go-swing');
+      expect(names).toContain('dilla-feel');
+    });
+
+    it('should have 13 presets total', () => {
+      expect(getGrooveTemplateNames().length).toBe(13);
+    });
+  });
+
+  describe('getGrooveTemplate', () => {
+    it('should return a template by name', () => {
+      const template = getGrooveTemplate('mpc-swing-66');
+      expect(template).toBeDefined();
+      expect(template!.name).toBe('mpc-swing-66');
+      expect(template!.category).toBe('swing');
+    });
+
+    it('should return undefined for unknown name', () => {
+      expect(getGrooveTemplate('nonexistent')).toBeUndefined();
+    });
+  });
+
+  describe('getGrooveTemplatesByCategory', () => {
+    it('should return swing presets', () => {
+      const swingPresets = getGrooveTemplatesByCategory('swing');
+      expect(swingPresets.length).toBe(5);
+      swingPresets.forEach(p => expect(p.category).toBe('swing'));
+    });
+
+    it('should return latin presets', () => {
+      const latinPresets = getGrooveTemplatesByCategory('latin');
+      expect(latinPresets.length).toBe(3);
+    });
+
+    it('should return funk presets', () => {
+      const funkPresets = getGrooveTemplatesByCategory('funk');
+      expect(funkPresets.length).toBe(3);
+    });
+
+    it('should return empty array for unused category', () => {
+      const otherPresets = getGrooveTemplatesByCategory('other');
+      expect(otherPresets.length).toBe(0);
+    });
+  });
+
+  describe('Template data integrity', () => {
+    it('all templates should have valid offset ranges (-0.5 to 0.5)', () => {
+      for (const [, template] of Object.entries(GROOVE_PRESETS)) {
+        for (let i = 0; i < template.offsets.length; i++) {
+          expect(template.offsets[i]).toBeGreaterThanOrEqual(-0.5);
+          expect(template.offsets[i]).toBeLessThanOrEqual(0.5);
+        }
+      }
+    });
+
+    it('all templates should have non-empty offsets', () => {
+      for (const template of Object.values(GROOVE_PRESETS)) {
+        expect(template.offsets.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('velocity arrays should match offset array length when present', () => {
+      for (const template of Object.values(GROOVE_PRESETS)) {
+        if (template.velocities) {
+          expect(template.velocities.length).toBe(template.offsets.length);
+        }
+      }
+    });
+
+    it('velocity values should be in range 0 to 2', () => {
+      for (const template of Object.values(GROOVE_PRESETS)) {
+        if (template.velocities) {
+          for (const vel of template.velocities) {
+            expect(vel).toBeGreaterThanOrEqual(0);
+            expect(vel).toBeLessThanOrEqual(2);
+          }
+        }
+      }
+    });
+
+    it('tempo ranges should be valid when present', () => {
+      for (const template of Object.values(GROOVE_PRESETS)) {
+        if (template.tempoRange) {
+          expect(template.tempoRange.min).toBeLessThan(template.tempoRange.max);
+          expect(template.tempoRange.min).toBeGreaterThanOrEqual(60);
+          expect(template.tempoRange.max).toBeLessThanOrEqual(200);
+        }
+      }
+    });
+  });
+
+  describe('MPC swing presets', () => {
+    it('MPC swing 54% should have correct offset', () => {
+      const t = getGrooveTemplate('mpc-swing-54')!;
+      expect(t.offsets).toEqual([0, 0.04]);
+    });
+
+    it('MPC swing 66% should have correct offset', () => {
+      const t = getGrooveTemplate('mpc-swing-66')!;
+      expect(t.offsets).toEqual([0, 0.16]);
+    });
+
+    it('MPC swing 71% should have correct offset', () => {
+      const t = getGrooveTemplate('mpc-swing-71')!;
+      expect(t.offsets).toEqual([0, 0.21]);
+    });
+
+    it('swing offsets should increase with percentage', () => {
+      const s54 = getGrooveTemplate('mpc-swing-54')!;
+      const s58 = getGrooveTemplate('mpc-swing-58')!;
+      const s62 = getGrooveTemplate('mpc-swing-62')!;
+      const s66 = getGrooveTemplate('mpc-swing-66')!;
+      const s71 = getGrooveTemplate('mpc-swing-71')!;
+      expect(s54.offsets[1]).toBeLessThan(s58.offsets[1]);
+      expect(s58.offsets[1]).toBeLessThan(s62.offsets[1]);
+      expect(s62.offsets[1]).toBeLessThan(s66.offsets[1]);
+      expect(s66.offsets[1]).toBeLessThan(s71.offsets[1]);
+    });
+  });
+
+  describe('applyGrooveTemplate', () => {
+    it('should return zero offset when amount is 0', () => {
+      const template = getGrooveTemplate('mpc-swing-66')!;
+      const result = applyGrooveTemplate(template, 1, 0);
+      expect(result.timingOffset).toBe(0);
+      expect(result.velocityScale).toBe(1.0);
+    });
+
+    it('should return full offset when amount is 1', () => {
+      const template = getGrooveTemplate('mpc-swing-66')!;
+      const result = applyGrooveTemplate(template, 1, 1);
+      expect(result.timingOffset).toBe(0.16);
+      expect(result.velocityScale).toBe(1.0); // no velocity array for MPC swing
+    });
+
+    it('should scale offset by amount', () => {
+      const template = getGrooveTemplate('mpc-swing-66')!;
+      const result = applyGrooveTemplate(template, 1, 0.5);
+      expect(result.timingOffset).toBeCloseTo(0.08, 5);
+    });
+
+    it('should cycle offsets for steps beyond array length', () => {
+      const template = getGrooveTemplate('mpc-swing-66')!;
+      // offsets length is 2, so step 3 maps to index 1
+      const result = applyGrooveTemplate(template, 3, 1);
+      expect(result.timingOffset).toBe(0.16);
+    });
+
+    it('should apply velocity scaling with amount', () => {
+      const template = getGrooveTemplate('bossa-nova')!;
+      // step 0 has velocity 1.1
+      const result = applyGrooveTemplate(template, 0, 1);
+      expect(result.velocityScale).toBeCloseTo(1.1, 5);
+    });
+
+    it('should blend velocity toward 1.0 with lower amount', () => {
+      const template = getGrooveTemplate('bossa-nova')!;
+      // step 0 velocity is 1.1, at amount=0.5 should be 1.0 + (1.1-1.0)*0.5 = 1.05
+      const result = applyGrooveTemplate(template, 0, 0.5);
+      expect(result.velocityScale).toBeCloseTo(1.05, 5);
+    });
+
+    it('should return 1.0 velocity scale for templates without velocities', () => {
+      const template = getGrooveTemplate('mpc-swing-66')!;
+      expect(template.velocities).toBeUndefined();
+      const result = applyGrooveTemplate(template, 0, 1);
+      expect(result.velocityScale).toBe(1.0);
+    });
+  });
+});

--- a/apps/web/src/services/groovePresets.ts
+++ b/apps/web/src/services/groovePresets.ts
@@ -1,0 +1,289 @@
+/**
+ * Groove preset library — named timing templates for the groove DSL.
+ *
+ * Each template provides per-step timing offsets (as fractions of a step
+ * interval) that repeat cyclically.  The `amount` parameter in the DSL
+ * scales these offsets linearly (0 = straight, 1 = full template feel).
+ *
+ * Offset convention:
+ *   positive = late / behind the beat (drag, swing)
+ *   negative = early / ahead of the beat (rush, push)
+ *   0        = on the grid
+ *
+ * Velocity multipliers (optional) adjust hit strength per step.
+ * 1.0 = unchanged, >1 = accent, <1 = ghost.
+ */
+
+import { GrooveTemplate, GroovePresetLibrary } from '../types/app';
+
+// ---------------------------------------------------------------------------
+// MPC-style swing presets
+// ---------------------------------------------------------------------------
+// MPC swing percentages shift every other 16th note (offbeat / even-indexed
+// in a 0-based 16th-note grid).  A "50%" swing is perfectly straight; higher
+// values push the offbeat later.  The offset fraction for a given percentage
+// is: (pct/100 - 0.5) * 2 * 0.5  =  (pct - 50) / 100
+//
+// For a 16-step pattern the cycle is 2 steps: [0, offset].
+
+function mpcSwing(pct: number, label: string): GrooveTemplate {
+  const offset = (pct - 50) / 100;
+  return {
+    name: `mpc-swing-${pct}`,
+    label,
+    category: 'swing',
+    description: `MPC-style ${pct}% swing — offbeats delayed by ${Math.round(offset * 100)}% of a step`,
+    offsets: [0, offset],
+    tempoRange: { min: 70, max: 140 },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Latin groove presets
+// ---------------------------------------------------------------------------
+
+/**
+ * Bossa nova — characteristic 16th-note pattern with subtle push-pull feel.
+ * Based on the classic João Gilberto guitar pattern interpreted on a 16-step
+ * grid.  Accents on the "and" of beat 2 and beat 4 give the signature lilt.
+ * 8-step cycle (repeats twice per bar in 16-step mode).
+ */
+const bossaNova: GrooveTemplate = {
+  name: 'bossa-nova',
+  label: 'Bossa Nova',
+  category: 'latin',
+  description: 'Classic bossa nova feel with subtle push on offbeats',
+  //                step:  1     e     &     a     2     e     &     a
+  offsets:              [  0,    0.05, -0.03, 0,    0,    0.08, -0.02, 0.04 ],
+  velocities:           [  1.1,  0.7,   0.9,  0.6,  1.0,  0.7,   1.2,   0.6 ],
+  tempoRange: { min: 110, max: 150 },
+};
+
+/**
+ * Son clave 3-2 — the foundational Afro-Cuban rhythmic pattern.
+ * 16-step cycle.  Offsets create the characteristic "in the cracks" feel
+ * between straight and triplet timing.
+ */
+const sonClave32: GrooveTemplate = {
+  name: 'son-clave-3-2',
+  label: 'Son Clave 3-2',
+  category: 'latin',
+  description: 'Afro-Cuban son clave 3-2 feel with micro-timing offsets',
+  // 16 steps — one full bar.
+  // Clave hits on steps 0, 3, 6, 10, 12 (0-indexed) get slight push/pull.
+  offsets: [
+    0,      0,     0,     0.06,   // beat 1: clave on 0, pull 3 late
+    0,      0,    -0.04,  0,      // beat 2: push 6 early
+    0,      0,     0.05,  0,      // beat 3: pull 10 late
+    -0.03,  0,     0,     0,      // beat 4: push 12 early
+  ],
+  velocities: [
+    1.2, 0.6, 0.7, 1.1,
+    0.6, 0.7, 1.2, 0.6,
+    0.7, 0.6, 1.1, 0.7,
+    1.2, 0.6, 0.7, 0.6,
+  ],
+  tempoRange: { min: 90, max: 130 },
+};
+
+/**
+ * Rumba clave 3-2 — variant with the third hit shifted one 16th later
+ * compared to son clave.  Creates a more syncopated, "in the crack" feel.
+ */
+const rumbaClave32: GrooveTemplate = {
+  name: 'rumba-clave-3-2',
+  label: 'Rumba Clave 3-2',
+  category: 'latin',
+  description: 'Rumba clave 3-2 with deeper syncopation offsets',
+  offsets: [
+    0,      0,     0,     0.06,
+    0,      0,     0,    -0.04,   // shifted from son clave — hit on 7 instead of 6
+    0,      0,     0.05,  0,
+    -0.03,  0,     0,     0,
+  ],
+  velocities: [
+    1.2, 0.6, 0.7, 1.1,
+    0.6, 0.7, 0.6, 1.2,
+    0.7, 0.6, 1.1, 0.7,
+    1.2, 0.6, 0.7, 0.6,
+  ],
+  tempoRange: { min: 90, max: 130 },
+};
+
+// ---------------------------------------------------------------------------
+// African-derived grooves
+// ---------------------------------------------------------------------------
+
+/**
+ * Afrobeat 12/8 — maps a 12/8 triplet feel onto the 16-step grid.
+ * Every third 16th note is pushed slightly late to approximate triplet
+ * groupings, creating the signature "rolling" Afrobeat feel (Fela Kuti style).
+ * 4-step repeating cycle.
+ */
+const afrobeat128: GrooveTemplate = {
+  name: 'afrobeat-12-8',
+  label: 'Afrobeat 12/8',
+  category: 'african',
+  description: 'Afrobeat triplet feel mapped to 16-step grid',
+  // 4-step cycle: downbeat, straight, pushed-late, straight
+  offsets:     [0, 0, 0.20, 0],
+  velocities:  [1.1, 0.8, 0.9, 0.7],
+  tempoRange: { min: 100, max: 140 },
+};
+
+// ---------------------------------------------------------------------------
+// Reggae grooves
+// ---------------------------------------------------------------------------
+
+/**
+ * Reggae one-drop — the classic roots reggae feel.  Kick and snare land on
+ * beat 3 with everything slightly behind the beat (dragged).  The skank
+ * (offbeat chords) get a subtle push for tension.
+ * 8-step cycle.
+ */
+const reggaeOneDrop: GrooveTemplate = {
+  name: 'reggae-one-drop',
+  label: 'Reggae One Drop',
+  category: 'reggae',
+  description: 'Roots reggae one-drop feel — behind the beat with offbeat push',
+  //               step:  1     e     &     a     2     e     &     a
+  offsets:            [  0.04,  0,   -0.03, 0.02,  0.04, 0,   -0.03, 0.02 ],
+  velocities:         [  1.0,   0.6,  1.1,  0.5,   1.2,  0.6,  1.1,  0.5 ],
+  tempoRange: { min: 65, max: 95 },
+};
+
+// ---------------------------------------------------------------------------
+// Funk / New Orleans grooves
+// ---------------------------------------------------------------------------
+
+/**
+ * New Orleans second line — the bouncing parade-beat feel.
+ * Characterized by a triplet-influenced "bounce" with strong accents on
+ * the "and" of beat 2 and the downbeat of beat 4.
+ * 16-step cycle.
+ */
+const secondLine: GrooveTemplate = {
+  name: 'second-line',
+  label: 'New Orleans Second Line',
+  category: 'funk',
+  description: 'New Orleans parade bounce with triplet-influenced timing',
+  offsets: [
+     0,     0.04,  0.15,  0,      // beat 1: triplet push on "a"
+     0,     0.04,  0.15,  0,      // beat 2: same bounce
+     0,     0.04,  0.15,  0,      // beat 3
+     0,     0.04,  0.15,  0,      // beat 4
+  ],
+  velocities: [
+    1.2, 0.7, 0.9, 0.6,
+    1.0, 0.7, 1.1, 0.6,
+    1.2, 0.7, 0.9, 0.6,
+    1.1, 0.7, 1.0, 0.6,
+  ],
+  tempoRange: { min: 100, max: 140 },
+};
+
+/**
+ * Go-go swing — the Washington D.C. go-go feel.
+ * Conga-driven bounce with a strong pocket between straight and swung 16ths.
+ * 4-step cycle with alternating push-pull.
+ */
+const goGoSwing: GrooveTemplate = {
+  name: 'go-go-swing',
+  label: 'Go-Go Swing',
+  category: 'funk',
+  description: 'D.C. go-go bounce with conga-driven pocket feel',
+  offsets:     [0, 0.10, 0, 0.08],
+  velocities:  [1.1, 0.8, 1.0, 0.9],
+  tempoRange: { min: 100, max: 130 },
+};
+
+/**
+ * J Dilla / lo-fi hip hop — the "drunk" or "human" feel made famous by
+ * J Dilla's MPC work.  Nearly every hit is slightly off-grid in different
+ * directions, creating a loose, organic pocket.
+ * 4-step cycle.
+ */
+const dillaFeel: GrooveTemplate = {
+  name: 'dilla-feel',
+  label: 'J Dilla Feel',
+  category: 'funk',
+  description: 'Loose, "drunk" MPC timing with push-pull on every hit',
+  offsets:     [0.02, -0.04, 0.06, -0.02],
+  velocities:  [1.0, 0.85, 0.95, 0.8],
+  tempoRange: { min: 70, max: 100 },
+};
+
+// ---------------------------------------------------------------------------
+// Build the preset library
+// ---------------------------------------------------------------------------
+
+const allPresets: GrooveTemplate[] = [
+  // MPC swing variants
+  mpcSwing(54, 'MPC Swing 54%'),
+  mpcSwing(58, 'MPC Swing 58%'),
+  mpcSwing(62, 'MPC Swing 62%'),
+  mpcSwing(66, 'MPC Swing 66%'),
+  mpcSwing(71, 'MPC Swing 71%'),
+
+  // Latin
+  bossaNova,
+  sonClave32,
+  rumbaClave32,
+
+  // African
+  afrobeat128,
+
+  // Reggae
+  reggaeOneDrop,
+
+  // Funk / New Orleans / Hip-hop
+  secondLine,
+  goGoSwing,
+  dillaFeel,
+];
+
+/** Named groove preset library — keyed by template name */
+export const GROOVE_PRESETS: GroovePresetLibrary = Object.fromEntries(
+  allPresets.map(preset => [preset.name, preset])
+);
+
+/** Get a groove template by name, or undefined if not found */
+export function getGrooveTemplate(name: string): GrooveTemplate | undefined {
+  return GROOVE_PRESETS[name];
+}
+
+/** Get all available template names */
+export function getGrooveTemplateNames(): string[] {
+  return Object.keys(GROOVE_PRESETS);
+}
+
+/** Get templates filtered by category */
+export function getGrooveTemplatesByCategory(category: GrooveTemplate['category']): GrooveTemplate[] {
+  return allPresets.filter(t => t.category === category);
+}
+
+/**
+ * Apply a groove template to a given step index.
+ * Returns the timing offset (in fractions of step interval) scaled by amount,
+ * and the velocity multiplier scaled toward 1.0 by (1 - amount).
+ */
+export function applyGrooveTemplate(
+  template: GrooveTemplate,
+  stepIndex: number,
+  amount: number
+): { timingOffset: number; velocityScale: number } {
+  const cycleLength = template.offsets.length;
+  const idx = stepIndex % cycleLength;
+
+  const rawOffset = template.offsets[idx];
+  const timingOffset = rawOffset * amount;
+
+  let velocityScale = 1.0;
+  if (template.velocities) {
+    const rawVel = template.velocities[idx];
+    // Blend between 1.0 (no effect) and the template velocity
+    velocityScale = 1.0 + (rawVel - 1.0) * amount;
+  }
+
+  return { timingOffset, velocityScale };
+}

--- a/apps/web/src/services/patternParser.groove.test.ts
+++ b/apps/web/src/services/patternParser.groove.test.ts
@@ -48,6 +48,41 @@ seq kick: x...`;
       const result = PatternParser.parse(pattern);
       expect(result.grooveModules?.kick.amount).toBe(1);
     });
+
+    it('should parse template groove with name', () => {
+      const pattern = `TEMPO 120
+groove master: type=template name=bossa-nova amount=0.8
+seq kick: x...x...`;
+      const result = PatternParser.parse(pattern);
+      expect(result.grooveModules?.master).toEqual({
+        name: 'master',
+        type: 'template',
+        amount: 0.8,
+        templateName: 'bossa-nova'
+      });
+    });
+
+    it('should parse template groove with MPC swing preset', () => {
+      const pattern = `TEMPO 120
+groove hihat: type=template name=mpc-swing-66 amount=0.7
+seq hihat: x.x.x.x.`;
+      const result = PatternParser.parse(pattern);
+      expect(result.grooveModules?.hihat).toEqual({
+        name: 'hihat',
+        type: 'template',
+        amount: 0.7,
+        templateName: 'mpc-swing-66'
+      });
+    });
+
+    it('should not include templateName for non-template types', () => {
+      const pattern = `TEMPO 120
+groove master: type=swing name=bossa-nova amount=0.5
+seq kick: x...x...`;
+      const result = PatternParser.parse(pattern);
+      expect(result.grooveModules?.master.type).toBe('swing');
+      expect(result.grooveModules?.master).not.toHaveProperty('templateName');
+    });
   });
 
   describe('Subdivision Parsing', () => {

--- a/apps/web/src/services/patternParser.ts
+++ b/apps/web/src/services/patternParser.ts
@@ -717,15 +717,15 @@ export class PatternParser {
    * Parse GROOVE string like "type=swing amount=0.5"
    */
   private static parseGrooveString(moduleName: string, grooveString: string): any {
-    const pairs = Array.from(grooveString.matchAll(/(type|amount|steps|subdivision)\s*=\s*([^\s]+)/gi));
+    const pairs = Array.from(grooveString.matchAll(/(type|amount|steps|subdivision|name)\s*=\s*([^\s]+)/gi));
     const map: Record<string, string> = {};
     for (const [, key, value] of pairs as any) {
       map[key.toLowerCase()] = String(value);
     }
 
     const typeStr = map['type']?.toLowerCase();
-    const allowedTypes = ['swing', 'humanize', 'rush', 'drag'];
-    const type = (allowedTypes.includes(typeStr) ? typeStr : 'swing') as 'swing' | 'humanize' | 'rush' | 'drag';
+    const allowedTypes = ['swing', 'humanize', 'rush', 'drag', 'template'];
+    const type = (allowedTypes.includes(typeStr) ? typeStr : 'swing') as 'swing' | 'humanize' | 'rush' | 'drag' | 'template';
 
     let amount = parseFloat(map['amount']);
     if (Number.isNaN(amount)) amount = 0.5;
@@ -744,13 +744,15 @@ export class PatternParser {
       };
       subdivision = subdivMap[rawSubdiv];
     }
+    const templateName = type === 'template' ? map['name']?.toLowerCase() : undefined;
 
     return {
       name: moduleName.toLowerCase(),
       type,
       amount,
       steps,
-      subdivision
+      subdivision,
+      ...(templateName && { templateName })
     };
   }
 

--- a/apps/web/src/services/unifiedAudioEngine.ts
+++ b/apps/web/src/services/unifiedAudioEngine.ts
@@ -1,6 +1,7 @@
 // Unified Audio Engine - Real-time everything, no pre-calculation
 import { ParsedPattern, UnifiedAudioState, LFOModule, FilterModule, DelayModule, ReverbModule, PanModule, DistortModule, ChorusModule, PhaserModule } from '../types/app';
 import { PatternParser } from './patternParser';
+import { applyGrooveTemplate, getGrooveTemplate } from './groovePresets';
 import * as Tone from 'tone';
 
 export interface ParameterUpdate {
@@ -1654,6 +1655,16 @@ export class UnifiedAudioEngine {
                 grooveOffset = -amount * 0.03;
               } else if (groove.type === 'drag') {
                 grooveOffset = amount * 0.03;
+              }
+            }
+
+            // Template groove: uses per-step offsets from a named preset
+            if (groove.type === 'template' && groove.templateName) {
+              const template = getGrooveTemplate(groove.templateName);
+              if (template) {
+                const applied = applyGrooveTemplate(template, step, amount);
+                grooveOffset = applied.timingOffset * stepInterval;
+                velocity = velocity * applied.velocityScale;
               }
             }
           }

--- a/apps/web/src/types/app.ts
+++ b/apps/web/src/types/app.ts
@@ -107,7 +107,40 @@ export interface SampleModule {
   gain?: number;
 }
 
-export type GrooveType = 'swing' | 'humanize' | 'rush' | 'drag';
+export type GrooveType = 'swing' | 'humanize' | 'rush' | 'drag' | 'template';
+
+/**
+ * A groove template defines per-step timing offsets and optional velocity
+ * adjustments for a repeating pattern cycle. Offsets are expressed as fractions
+ * of a step interval (-0.5 to +0.5, where +0.33 ≈ MPC swing).
+ */
+export interface GrooveTemplate {
+  /** Unique kebab-case identifier, e.g. 'mpc-swing-66' */
+  name: string;
+  /** Human-readable label */
+  label: string;
+  /** Grouping category for UI */
+  category: 'swing' | 'latin' | 'african' | 'reggae' | 'funk' | 'other';
+  /** Short description */
+  description: string;
+  /**
+   * Per-step timing offsets as fractions of the step interval.
+   * Length determines the cycle — offsets repeat modulo this length.
+   * Positive = late (behind the beat), negative = early (ahead).
+   * Range: -0.5 to +0.5
+   */
+  offsets: number[];
+  /**
+   * Optional per-step velocity multipliers (0.0 to 2.0, default 1.0).
+   * Same length as offsets. Applied multiplicatively to existing velocity.
+   */
+  velocities?: number[];
+  /** Suggested tempo range for best feel */
+  tempoRange?: { min: number; max: number };
+}
+
+/** Dictionary of named groove templates */
+export type GroovePresetLibrary = Record<string, GrooveTemplate>;
 
 export interface GrooveModule {
   name: string; // 'master' or instrument name
@@ -115,6 +148,8 @@ export interface GrooveModule {
   amount: number; // 0..1 (intensity)
   steps?: 'all' | 'odd' | 'even' | string; // Which steps to apply to
   subdivision?: '4n' | '8n' | '16n';
+  /** Template preset name — required when type='template' */
+  templateName?: string;
 }
 
 export interface ParsedPattern {


### PR DESCRIPTION
## Summary
Adds a groove template system with per-step timing offsets and velocity shaping for genre-specific grooves. Built on top of the subdivision-aware swing system from PR #15.

## New DSL Syntax
```
groove master: type=template name=bossa-nova amount=0.8
groove kick: type=template name=mpc-swing-66 amount=0.7
```

The `amount` parameter (0-1) scales template intensity. Existing groove types (swing, humanize, rush, drag) are unaffected.

## 13 Presets Across 5 Categories
- **Swing**: MPC 54%, 58%, 62%, 66% (triplet), 71%
- **Latin**: Bossa Nova, Son Clave 3-2, Rumba Clave 3-2
- **African**: Afrobeat 12/8
- **Reggae**: One Drop
- **Funk**: New Orleans Second Line, Go-Go Swing, J Dilla Feel

## Changes
| File | Change |
|------|--------|
| `apps/web/src/services/groovePresets.ts` | **New** — 13 templates + lookup helpers |
| `apps/web/src/services/groovePresets.test.ts` | **New** — 24 tests for presets |
| `apps/web/src/types/app.ts` | Added `GrooveTemplate`, `GroovePresetLibrary` types, `'template'` groove type |
| `apps/web/src/services/patternParser.ts` | Parse `type=template name=<preset>` |
| `apps/web/src/services/patternParser.groove.test.ts` | 3 new template parsing tests |
| `apps/web/src/services/unifiedAudioEngine.ts` | Apply template offsets + velocity in `rebuildTonePart()` |
| `api/_lib/system-prompt.ts` | Document template syntax + preset list |

## Test Plan
- [x] All 445 tests pass (`pnpm test`)
- [x] Type-check clean (`pnpm turbo run type-check`)
- [x] Existing swing/humanize/rush/drag unaffected
- [x] Template offsets scale correctly with amount parameter
- [x] Velocity multipliers blend toward 1.0 as amount decreases

🤖 Generated with [Claude Code](https://claude.com/claude-code)